### PR TITLE
Add short link for AB FAQ

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -2,3 +2,4 @@
 | Folder | Link | Redirects to |
 | :---   | :--- | :---         |
 | d43    | https://andbible.org/go/d43 | [FAQ: How do I downgrade from 4.0 to 3.3?](https://github.com/AndBible/and-bible/wiki/FAQ#how-do-i-downgrade-from-40-to-33) |
+| faq    | https://andbible.org/go/faq | [FAQ](https://github.com/AndBible/and-bible/wiki/FAQ) |

--- a/go/faq/index.html
+++ b/go/faq/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+   <head>
+      <title>Redirecting</title>
+      <meta http-equiv = "refresh" content = "0; url = https://github.com/AndBible/and-bible/wiki/FAQ" />
+   </head>
+   <body>
+   </body>
+</html>


### PR DESCRIPTION
Add another short link for FAQ. In the future the redirect could be changed for example if the FAQ was moved to readthedocs
Short link = https://andbible.org/go/faq